### PR TITLE
fixed join button permanent loading bug

### DIFF
--- a/tracktogether-frontend/src/pages/Groups/Groups.js
+++ b/tracktogether-frontend/src/pages/Groups/Groups.js
@@ -79,6 +79,7 @@ function Group() {
                 // throw new Error(errorMessage);
                 console.log(data.message);
                 setJoinErrorMessage(data.message);
+                setJoinLoading(false);
               });
             }
           })


### PR DESCRIPTION
i have fixed the join group button loading permanently upon failure to join a group.